### PR TITLE
Allow user to set the scrollback value

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,8 @@
 ### Added
 
 -   Custom baud rate support.
+-   Option to edit the number of lines that can be scrolled back. The default
+    `scrollback` is set to 1000 lines.
 
 ### Changed
 

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -13,6 +13,7 @@ import { XTerm } from 'xterm-for-react';
 
 import {
     getEchoOnShell,
+    getScrollback,
     getSerialPort,
 } from '../../features/terminal/terminalSlice';
 import useFitAddon from '../../hooks/useFitAddon';
@@ -50,6 +51,7 @@ export default ({
     const fitAddon = useFitAddon(height, width, lineMode);
     const echoOnShell = useSelector(getEchoOnShell);
     const serialPort = useSelector(getSerialPort);
+    const scrollback = useSelector(getScrollback);
 
     const writeLineModeToXterm = (data: string) => {
         if (data.length === 1 && data.charCodeAt(0) === 12) return;
@@ -174,7 +176,15 @@ export default ({
             background: styles.terminalBackground,
         },
         disableStdin: lineMode, // Line mode user needs to use the input field not the terminal
+        scrollback,
     };
+
+    if (
+        xtermRef.current &&
+        xtermRef.current?.terminal.options.scrollback !== scrollback
+    ) {
+        xtermRef.current.terminal.options.scrollback = scrollback;
+    }
 
     useEffect(() => {
         if (xtermRef.current != null) {

--- a/src/components/Terminal/TerminalSettings.tsx
+++ b/src/components/Terminal/TerminalSettings.tsx
@@ -140,8 +140,12 @@ export default () => {
     ]);
 
     return (
-        <CollapsibleGroup heading="Terminal Settings">
-            <div title="Set the number of lines that can scrolled back in one session.">
+        <CollapsibleGroup heading="Terminal Settings" defaultCollapsed={false}>
+            <div
+                title="Set the number of lines it is possible to scroll in the Terminal"
+                className="tw-flex tw-justify-between"
+            >
+                Scrollback
                 <NumberInlineInput
                     disabled={isConnected}
                     value={scrollback}
@@ -151,9 +155,8 @@ export default () => {
                             dispatch(setActiveScrollback(scrollback));
                         }
                     }}
-                    range={{ min: 1, max: 2 ** 64 - 1, decimals: 0 }}
+                    range={{ min: 1, max: 2 ** 64 - 1 }}
                 />
-                <span>Scrollback history</span>
             </div>
             <StateSelector
                 items={lineModeItems}

--- a/src/components/Terminal/TerminalSettings.tsx
+++ b/src/components/Terminal/TerminalSettings.tsx
@@ -147,7 +147,6 @@ export default () => {
             >
                 Scrollback
                 <NumberInlineInput
-                    disabled={isConnected}
                     value={scrollback}
                     onChange={setScrollback}
                     onChangeComplete={() => {

--- a/src/components/Terminal/TerminalSettings.tsx
+++ b/src/components/Terminal/TerminalSettings.tsx
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
     CollapsibleGroup,
     Dropdown,
     getPersistedTerminalSettings,
+    NumberInlineInput,
     persistTerminalSettings,
     selectedDevice,
     StateSelector,
@@ -21,6 +22,7 @@ import {
     getEchoOnShell,
     getLineEnding,
     getLineMode,
+    getScrollback,
     getSerialOptions,
     getSerialPort,
     LineEnding,
@@ -28,6 +30,7 @@ import {
     setEchoOnShell,
     setLineEnding,
     setLineMode,
+    setScrollback as setActiveScrollback,
 } from '../../features/terminal/terminalSlice';
 import { convertToDropDownItems } from '../../utils/dataConstructors';
 
@@ -37,6 +40,9 @@ export default () => {
     const lastModemOpenState = useRef(false);
     const selectedSerialport = useSelector(getSerialOptions).path;
 
+    const activeScrollback = useSelector(getScrollback);
+    const [scrollback, setScrollback] = useState(activeScrollback);
+
     const clearOnSend = useSelector(getClearOnSend);
     const lineEnding = useSelector(getLineEnding);
     const echoOnShell = useSelector(getEchoOnShell);
@@ -44,6 +50,8 @@ export default () => {
     const lineMode = useSelector(getLineMode);
 
     const dispatch = useDispatch();
+
+    const isConnected = serialPort !== undefined;
 
     const lineEndings = convertToDropDownItems<string>(
         ['NONE', 'LF', 'CR', 'CRLF'],
@@ -133,6 +141,20 @@ export default () => {
 
     return (
         <CollapsibleGroup heading="Terminal Settings">
+            <div title="Set the number of lines that can scrolled back in one session.">
+                <NumberInlineInput
+                    disabled={isConnected}
+                    value={scrollback}
+                    onChange={setScrollback}
+                    onChangeComplete={() => {
+                        if (scrollback !== activeScrollback) {
+                            dispatch(setActiveScrollback(scrollback));
+                        }
+                    }}
+                    range={{ min: 1, max: 2 ** 64 - 1, decimals: 0 }}
+                />
+                <span>Scrollback history</span>
+            </div>
             <StateSelector
                 items={lineModeItems}
                 onSelect={value => dispatch(setLineMode(value === 0))}

--- a/src/features/terminal/terminalSlice.ts
+++ b/src/features/terminal/terminalSlice.ts
@@ -22,6 +22,7 @@ interface TerminalState {
     lineMode: boolean;
     echoOnShell: boolean;
     showOverwriteDialog: boolean;
+    scrollback: number;
 }
 
 const initialState: TerminalState = {
@@ -36,6 +37,7 @@ const initialState: TerminalState = {
     lineMode: true,
     echoOnShell: true,
     showOverwriteDialog: false,
+    scrollback: 1000, // Default by Xterm.js
 };
 
 const cleanUndefined = <T>(obj: T) => JSON.parse(JSON.stringify(obj));
@@ -95,6 +97,12 @@ const terminalSlice = createSlice({
         setShowOverwriteDialog: (state, action: PayloadAction<boolean>) => {
             state.showOverwriteDialog = action.payload;
         },
+        setScrollback: (
+            state,
+            { payload: scrollback }: PayloadAction<number>
+        ) => {
+            state.scrollback = scrollback;
+        },
     },
 });
 
@@ -113,6 +121,8 @@ export const getEchoOnShell = (state: RootState) =>
     state.app.terminal.echoOnShell;
 export const getShowOverwriteDialog = (state: RootState) =>
     state.app.terminal.showOverwriteDialog;
+export const getScrollback = (state: RootState) =>
+    state.app.terminal.scrollback;
 
 export const {
     setSerialPort,
@@ -125,5 +135,6 @@ export const {
     setLineMode,
     setEchoOnShell,
     setShowOverwriteDialog,
+    setScrollback,
 } = terminalSlice.actions;
 export default terminalSlice.reducer;


### PR DESCRIPTION
The scrollback is how many lines will be kept in the terminal buffer. Updating the scrollback should only be allowed while not directly interacting with a device, meaning before you connect to a serial port.

---

In order to test, you could add a button in `src/components/Terminal/Terminal.tsx` that prints the line numbers, so that it's easy to assess how many lines are kept in the Terminal Window.
```tsx
<button
    type="button"
    className="clear-console tw-right-32"
    onClick={() => {
        for (let i = 1; i <= 2000; i += 1) {
            xtermRef.current?.terminal.writeln(`Line: ${i}`);
        }
    }}
>
    Print lines
</button>
```