### PR TITLE
Add iterative scroll back after typing

### DIFF
--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -291,7 +291,13 @@ export default ({
                             }}
                             onKeyDown={event => {
                                 if (event.key === 'Enter') {
-                                    handleUserInputLineMode(cmdLine);
+                                    if (historyLine) {
+                                        handleUserInputLineMode(historyLine);
+                                        setHistoryLine(undefined);
+                                        resetHistoryScroll();
+                                    } else {
+                                        handleUserInputLineMode(cmdLine);
+                                    }
                                 }
                                 if (event.key === 'ArrowUp') {
                                     // This is needed to prevent the cursor to go to start

--- a/src/features/history/effects.ts
+++ b/src/features/history/effects.ts
@@ -239,3 +239,31 @@ const writeHistory =
 
         dispatch(setNumberOfLinesInHistory(history.length));
     };
+
+export const resetHistoryScroll = () => historyBuffer?.resetScrollIndex();
+
+export const scrollBack = (input: string) => {
+    if (historyBuffer == null) {
+        logger.error(HISTORY_BUFFER_NOT_INITIALIZED_MESSAGE);
+        return;
+    }
+
+    if (input.trim() === '') {
+        return historyBuffer.scrollBackOnce();
+    }
+
+    return historyBuffer.scrollBackSearch(input);
+};
+
+export const scrollForward = (input: string) => {
+    if (historyBuffer == null) {
+        logger.error(HISTORY_BUFFER_NOT_INITIALIZED_MESSAGE);
+        return;
+    }
+
+    if (input.trim() === '') {
+        return historyBuffer.scrollForwardOnce();
+    }
+
+    return historyBuffer.scrollForwardSearch(input);
+};

--- a/src/features/history/effects.ts
+++ b/src/features/history/effects.ts
@@ -68,7 +68,6 @@ export const initializeHistoryBuffer: AppThunk<RootState> = async (
                 return;
             }
 
-            historyBuffer.redoHistoryMap();
             dispatch(setNumberOfLinesInHistory(numberOfLines));
         }
     });

--- a/src/features/history/historyBuffer.ts
+++ b/src/features/history/historyBuffer.ts
@@ -47,24 +47,6 @@ const HistoryBufferWrapper = async (pathToHistory: string) => {
     }
     let history: string[] = initialHistory;
 
-    const createMap = () =>
-        history
-            .slice()
-            .map(line => {
-                const command = line.slice(line.indexOf(': '));
-                return command;
-            })
-            .forEach(command => {
-                const commandCount = historyMap.get(command) ?? 0;
-                historyMap.set(command, commandCount + 1);
-            });
-
-    // Map with <commandSent, numberOfTimesItWasSent>
-    // NB: at the time of writing, this map will initialized when the buffer is initialized, and after
-    // that it will only be appended to. Meaning that the history and the historyMap may go out of sync,
-    // but this should not be an issue. In other words, the map is going to contain more data than then
-    // the history, if and only if, the history is truncated/trimmed.
-    const historyMap = new Map<string, number>();
     let currentLineIndex = history.length;
     let lastSearchHit: string | undefined;
 
@@ -74,8 +56,6 @@ const HistoryBufferWrapper = async (pathToHistory: string) => {
                 return;
             }
             history.push(`${new Date(Date.now()).toISOString()}: ${line}`);
-            const commandCount = historyMap.get(line) ?? 0;
-            historyMap.set(line, commandCount + 1);
         },
 
         trimDownToNumberOfLinesToKeep: (numberOfLinesToKeep: number) => {
@@ -93,7 +73,6 @@ const HistoryBufferWrapper = async (pathToHistory: string) => {
 
         getNumberOfLines: () => history.length,
         getHistory: () => history,
-        getHistoryMap: () => historyMap,
 
         refreshHistoryFromFile: async (path: string) => {
             const newHistory = await getHistoryFromFile(path);
@@ -105,10 +84,6 @@ const HistoryBufferWrapper = async (pathToHistory: string) => {
             }
             history = [...newHistory];
             return history.length;
-        },
-        redoHistoryMap: () => {
-            historyMap.clear();
-            createMap();
         },
 
         resetScrollIndex: () => {

--- a/src/features/history/historyBuffer.ts
+++ b/src/features/history/historyBuffer.ts
@@ -55,6 +55,16 @@ const HistoryBufferWrapper = async (pathToHistory: string) => {
             if (line.trim() === '') {
                 return;
             }
+
+            const lastLine = history.at(-1);
+            if (
+                lastLine != null &&
+                getCommandFromHistoryEntry(lastLine) === line
+            ) {
+                // Do not record sequential duplicates.
+                return;
+            }
+
             history.push(`${new Date(Date.now()).toISOString()}: ${line}`);
         },
 

--- a/src/features/history/historyBuffer.ts
+++ b/src/features/history/historyBuffer.ts
@@ -66,6 +66,7 @@ const HistoryBufferWrapper = async (pathToHistory: string) => {
     // the history, if and only if, the history is truncated/trimmed.
     const historyMap = new Map<string, number>();
     let currentLineIndex = history.length;
+    let lastSearchHit: string | undefined;
 
     return {
         pushLineToHistory: (line: string) => {
@@ -112,48 +113,66 @@ const HistoryBufferWrapper = async (pathToHistory: string) => {
 
         resetScrollIndex: () => {
             currentLineIndex = history.length;
+            lastSearchHit = undefined;
         },
 
         scrollBackSearch: (input: string) => {
-            if (currentLineIndex === history.length) {
-                currentLineIndex -= 1;
+            if (currentLineIndex === 0) {
+                return undefined;
             }
+
+            currentLineIndex -= 1;
             let nextLine = getCommandFromHistoryEntry(
                 history.at(currentLineIndex)
             );
 
-            while (nextLine != null && !nextLine.startsWith(input)) {
-                currentLineIndex -= 1;
-
-                if (currentLineIndex === -1) {
-                    currentLineIndex = history.length;
+            while (
+                (nextLine != null && !nextLine.startsWith(input)) ||
+                nextLine === input ||
+                nextLine === lastSearchHit
+            ) {
+                if (currentLineIndex === 0) {
                     return undefined;
                 }
 
+                currentLineIndex -= 1;
                 nextLine = getCommandFromHistoryEntry(
                     history.at(currentLineIndex)
                 );
             }
 
+            lastSearchHit = nextLine;
             return nextLine;
         },
 
         scrollForwardSearch: (input: string) => {
+            if (currentLineIndex === history.length) {
+                return undefined;
+            }
+
+            currentLineIndex += 1;
             let nextLine = getCommandFromHistoryEntry(
                 history.at(currentLineIndex)
             );
 
-            while (nextLine != null && !nextLine.startsWith(input)) {
+            while (
+                (nextLine != null && !nextLine.startsWith(input)) ||
+                nextLine === input ||
+                nextLine === lastSearchHit
+            ) {
+                currentLineIndex += 1;
+
                 if (currentLineIndex === history.length) {
+                    lastSearchHit = undefined;
                     return undefined;
                 }
 
-                currentLineIndex += 1;
                 nextLine = getCommandFromHistoryEntry(
                     history.at(currentLineIndex)
                 );
             }
 
+            lastSearchHit = nextLine;
             return nextLine;
         },
 

--- a/src/features/history/historyBuffer.ts
+++ b/src/features/history/historyBuffer.ts
@@ -65,6 +65,7 @@ const HistoryBufferWrapper = async (pathToHistory: string) => {
     // but this should not be an issue. In other words, the map is going to contain more data than then
     // the history, if and only if, the history is truncated/trimmed.
     const historyMap = new Map<string, number>();
+    let currentLineIndex = history.length;
 
     return {
         pushLineToHistory: (line: string) => {
@@ -108,7 +109,76 @@ const HistoryBufferWrapper = async (pathToHistory: string) => {
             historyMap.clear();
             createMap();
         },
+
+        resetScrollIndex: () => {
+            currentLineIndex = history.length;
+        },
+
+        scrollBackSearch: (input: string) => {
+            if (currentLineIndex === history.length) {
+                currentLineIndex -= 1;
+            }
+            let nextLine = getCommandFromHistoryEntry(
+                history.at(currentLineIndex)
+            );
+
+            while (nextLine != null && !nextLine.startsWith(input)) {
+                currentLineIndex -= 1;
+
+                if (currentLineIndex === -1) {
+                    currentLineIndex = history.length;
+                    return undefined;
+                }
+
+                nextLine = getCommandFromHistoryEntry(
+                    history.at(currentLineIndex)
+                );
+            }
+
+            return nextLine;
+        },
+
+        scrollForwardSearch: (input: string) => {
+            let nextLine = getCommandFromHistoryEntry(
+                history.at(currentLineIndex)
+            );
+
+            while (nextLine != null && !nextLine.startsWith(input)) {
+                if (currentLineIndex === history.length) {
+                    return undefined;
+                }
+
+                currentLineIndex += 1;
+                nextLine = getCommandFromHistoryEntry(
+                    history.at(currentLineIndex)
+                );
+            }
+
+            return nextLine;
+        },
+
+        scrollBackOnce: () => {
+            if (currentLineIndex === 0) {
+                return;
+            }
+            currentLineIndex -= 1;
+            return getCommandFromHistoryEntry(history.at(currentLineIndex));
+        },
+        scrollForwardOnce: () => {
+            if (currentLineIndex === history.length) {
+                return;
+            }
+            currentLineIndex += 1;
+            return getCommandFromHistoryEntry(history.at(currentLineIndex));
+        },
     };
 };
 
 export default HistoryBufferWrapper;
+
+const getCommandFromHistoryEntry = (entry?: string) => {
+    if (entry == null) {
+        return undefined;
+    }
+    return entry.slice(entry.indexOf(': ') + 2).trim();
+};


### PR DESCRIPTION
As a user of Serial Terminal I want to find previously used commands by clicking arrow-up and arrow-down to browse through the history.

If I have started typing, and then click arrow-up, I want to find the commands that start with the same text as I've already typed into the input field.

Note: This feature is only relevant for Line Mode, as it should be implemented by the shell, running on the device, when shell mode is used.

## Key Feature

- In line mode `arrow-up` will give the previous command sent through the terminal
- Use `arrow-up` and `arrow-down` to go back and forth in the history of commands
- If you start to type, the `arrow-up` and `arrow-down` will search for previous commands with the same beginning as what is typed into the input field.

## Limitations

- The `.history` file is shared between **Line Mode** and **Shell Mode**, meaning that if you have used shell mode, and then go into line mode, you will browse through the commands sent through shell mode as well. This may not be what the user actually wants, as the command won't necesarrily look good.