### PR TITLE
NCD-643: should always update index

### DIFF
--- a/src/features/history/historyBuffer.ts
+++ b/src/features/history/historyBuffer.ts
@@ -66,6 +66,7 @@ const HistoryBufferWrapper = async (pathToHistory: string) => {
             }
 
             history.push(`${new Date(Date.now()).toISOString()}: ${line}`);
+            currentLineIndex = history.length;
         },
 
         trimDownToNumberOfLinesToKeep: (numberOfLinesToKeep: number) => {


### PR DESCRIPTION
The internal `currentLineIndex` was not properly updated between each write to the history, meaning that we had a one-off problem. On each write we should always update the currentLineIndex to the end of the history + 1, meaning the length of the history. This means that when we decrement the `currentLineIndex` on _arrow up_ we go to the last entry in the history buffer.