### PR TITLE
index for backward search must be updated

### DIFF
--- a/src/features/history/historyBuffer.ts
+++ b/src/features/history/historyBuffer.ts
@@ -80,6 +80,7 @@ const HistoryBufferWrapper = async (pathToHistory: string) => {
             logger.debug(
                 `Deleted ${numberOfLinesToDelete} lines from history file, it should not only contain ${numberOfLinesToKeep} lines.`
             );
+            currentLineIndex = history.length;
         },
 
         getNumberOfLines: () => history.length,


### PR DESCRIPTION
When the history file is full, the history buffer is also trimmed, but only after the new entry is pushed to the list and the currentLineIndex is updated.

In order for the index to be properly updated, an additional update is added to the trimming function. Else the index would be one-off, and it would require the user to click arrow up twice to see the last entry.