### PR TITLE
doc: update Infocenter links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,16 @@
 [![Build Status](https://dev.azure.com/NordicSemiconductor/Wayland/_apis/build/status/pc-nrfconnect-serial-terminal?branchName=main)](https://dev.azure.com/NordicSemiconductor/Wayland/_build/latest?definitionId=126&branchName=main)
 [![License](https://img.shields.io/badge/license-Modified%20BSD%20License-blue.svg)](LICENSE)
 
-_nRF Serial Terminal_ is a tool that allows you to connect to serial devices.
+nRF Serial Terminal is a tool that allows you to connect to serial devices.
 
 ![screenshot](resources/screenshoot.gif)
 
 ## Installation
 
-See the
-[InfoCenter](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fstruct_nrftools%2Fstruct%2Fnrftools_nrfconnect.html)
-pages for information on how to install the application.
+nRF Serial Terminal is installed from nRF Connect from Desktop. For detailed
+steps, see
+[Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html)
+in the nRF Connect from Desktop documentation.
 
 ## Development
 
@@ -27,7 +28,7 @@ Please report issues on the [DevZone](https://devzone.nordicsemi.com) portal.
 ## Contributing
 
 See the
-[infos on contributing](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/contributing)
+[information on contributing](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/contributing)
 for details.
 
 ## License

--- a/src/components/DocumentationSection.tsx
+++ b/src/components/DocumentationSection.tsx
@@ -13,7 +13,8 @@ const DocumentationSections = [
         linkLabel="Go to TechDocs"
         link="https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/index.html"
     >
-        Visit our Technical Documentation for more documentation about using the app.
+        Visit our Technical Documentation for more documentation about using the
+        app.
     </DocumentationSection>,
 ];
 

--- a/src/components/DocumentationSection.tsx
+++ b/src/components/DocumentationSection.tsx
@@ -10,10 +10,10 @@ import { DocumentationSection } from '@nordicsemiconductor/pc-nrfconnect-shared'
 const DocumentationSections = [
     <DocumentationSection
         key="infocenter"
-        linkLabel="Go to Infocenter"
-        link="https://infocenter.nordicsemi.com/topic/ug_serial_terminal/UG/serial_terminal/intro.html"
+        linkLabel="Go to TechDocs"
+        link="https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/index.html"
     >
-        Visit our Infocenter for more documentation about using the app.
+        Visit our Technical Documentation for more documentation about using the app.
     </DocumentationSection>,
 ];
 


### PR DESCRIPTION
Replaced links to Infocenter with TechDocs ones.