### PR TITLE
fix: ensure that terminal gets resized during startup

### DIFF
--- a/src/hooks/useFitAddon.ts
+++ b/src/hooks/useFitAddon.ts
@@ -11,7 +11,7 @@ const fitAddon = new FitAddon();
 
 export default (height = 0, width = 0, lineMode = false) => {
     useEffect(() => {
-        if (width * height > 0) fitAddon.fit();
+        if (width * height > 0) setTimeout(() => fitAddon.fit());
     }, [width, height, lineMode]);
 
     return fitAddon;


### PR DESCRIPTION
I believe the event happened in a weird timing due to some react magic