### PR TITLE
doc: rename application + other edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# nRF Serial Terminal
+# Serial Terminal app
 
 [![Build Status](https://dev.azure.com/NordicSemiconductor/Wayland/_apis/build/status/pc-nrfconnect-serial-terminal?branchName=main)](https://dev.azure.com/NordicSemiconductor/Wayland/_build/latest?definitionId=126&branchName=main)
 [![License](https://img.shields.io/badge/license-Modified%20BSD%20License-blue.svg)](LICENSE)
 
-nRF Serial Terminal is a tool that allows you to connect to serial devices.
+The Serial Terminal app allows you to connect to serial devices.
 
 ![screenshot](resources/screenshoot.gif)
 
 ## Installation
 
-nRF Serial Terminal is installed from nRF Connect from Desktop. For detailed
+The Serial Terminal app is installed from nRF Connect from Desktop. For detailed
 steps, see
 [Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html)
 in the nRF Connect from Desktop documentation.

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -1,19 +1,19 @@
-# nRF Connect Serial Terminal
+# {{app_name}}
 
-nRF Connect Serial Terminal is a cross-platform terminal emulator for serial port communications with Nordic Semiconductor devices over Universal Asynchronous Receiver/Transmitter (UART).
+The {{app_name}} is a cross-platform terminal emulator for serial port communications with Nordic Semiconductor devices over Universal Asynchronous Receiver/Transmitter (UART).
 It can be used as an alternative to tools such as PuTTY and minicom.
 
-Serial Terminal is installed and updated using [nRF Connect for Desktop](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/index.html).
+{{app_name}} is installed and updated using [nRF Connect for Desktop](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/index.html).
 
-## Serial Terminal features
+## {{app_name}} features
 
 - Configure, monitor, and communicate with virtual serial ports on Nordic Semiconductor devices.
 - Check logging output and enter console inputs when programming or debugging applications.
 - Use one of two available terminal modes: the shell mode for sending commands to a device running a shell, such as Zephyr™ shell, or the line mode.
 - Quickly locate warnings and errors thanks to the ANSI escape code support.
 - Resume interrupted work thanks to device auto-detection, auto-reconnection, and persistence of both the device settings and the terminal input and output.
-- Use other nRF Connect for Desktop applications that require access to the serial port, for example [nRF Connect Cellular Monitor](https://docs.nordicsemi.com/bundle/nrf-connect-cellularmonitor/page/index.html), while you are working with Serial Terminal by leveraging shared access to the connected device's serial port.
+- Use other nRF Connect for Desktop applications that require access to the serial port, for example [nRF Connect Cellular Monitor](https://docs.nordicsemi.com/bundle/nrf-connect-cellularmonitor/page/index.html), while you are working with the {{app_name}} by leveraging shared access to the connected device's serial port.
 
 ## Supported devices
 
-Serial Terminal supports Nordic Semiconductor Development Kits (DKs) and prototyping platforms. It is also compatible with all devices that have a USB-to-UART converter onboard that allows serial communication to a computer.
+The {{app_name}} supports Nordic Semiconductor Development Kits (DKs) and prototyping platforms. It is also compatible with all devices that have a USB-to-UART converter onboard that allows serial communication to a computer.

--- a/doc/docs/installing.md
+++ b/doc/docs/installing.md
@@ -1,3 +1,3 @@
-# Installing Serial Terminal app
+# Installing the {{app_name}}
 
 For installation instructions, see [Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html) in the nRF Connect for Desktop documentation.

--- a/doc/docs/overview.md
+++ b/doc/docs/overview.md
@@ -1,9 +1,9 @@
 # Overview and user interface
 
-When you start the Serial Terminal app, the application main window appears with no device selected and the console empty.
+When you start the {{app_name}}, the application main window appears with no device selected and the console empty.
 In the background, the application initializes the required nRF Util module and detects the devices connected to the computer, as you can see in the log:
 
-![nRF Connect Serial Terminal default view at startup](./screenshots/serial_term_startup.png "nRF Connect Serial Terminal default view")
+![{{app_name}} default view at startup](./screenshots/serial_term_startup.png "{{app_name}} default view")
 
 ## Select Device
 

--- a/doc/docs/revision_history.md
+++ b/doc/docs/revision_history.md
@@ -2,6 +2,7 @@
 
 |     Date     |                                                                  Description                                                                   |
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| November 2024 | Editorial changes |
 | October 2024 | Updated for [nRF Connect Serial Terminal v1.4.2](https://github.com/NordicSemiconductor/pc-nrfconnect-serial-terminal/blob/main/Changelog.md). |
 | January 2024 | Updated for [nRF Connect Serial Terminal v1.3.0](https://github.com/NordicSemiconductor/pc-nrfconnect-serial-terminal/blob/main/Changelog.md). |
 | June 2023    | First release                                                                                                                                  |

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: nRF Connect Serial Terminal documentation
+site_name: Serial Terminal app documentation
 site_url:
 use_directory_urls: false
 
@@ -30,7 +30,7 @@ extra_css:
   - stylesheets/style.css
 
 copyright:
-  Copyright &copy; 2023
+  Copyright &copy; 2023-2024
 
 markdown_extensions:
   - abbr
@@ -42,9 +42,6 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.tabbed
   - pymdownx.superfences
-  - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
   - toc:
       permalink: true
       toc_depth: 4
@@ -56,10 +53,11 @@ plugins:
 
 extra:
   test: This is a test abbreviation snippet
+  app_name: Serial Terminal app
 
 nav:
   - Home: index.md
-  - Installing Serial Terminal app: installing.md
+  - Installing the Serial Terminal app: installing.md
   - Overview and user interface: overview.md
   - Getting started: connecting.md
   - Selecting a serial port: selecting_serial_port.md

--- a/doc/zoomin/custom.properties
+++ b/doc/zoomin/custom.properties
@@ -1,3 +1,3 @@
 manual.name=nrf-connect-serial-terminal
-booktitle=nRF Connect Serial Terminal
-shortdesc=Documentation for the nRF Connect Serial Terminal application.
+booktitle=Serial Terminal app
+shortdesc=Documentation for the Serial Terminal application.


### PR DESCRIPTION
Dropped `nRF Connect` from the app name.
Updated copyright year.
Added app name abbreviation.
Removed unused extensions.
NCD-1066.