### PR TITLE
Bump nrfutil-core to 8.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
             ]
         },
         "html": "dist/index.html",
-        "nrfutilCore": "8.0.0"
+        "nrfutilCore": "8.1.1"
     },
     "main": "dist/bundle.js",
     "files": [


### PR DESCRIPTION
Bump nrfutil-core to 8.1.1. Because https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/issues/1189 showed that it is necessary for some users.