### PR TITLE
terminal: Persist scrollback setting

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -14,6 +14,7 @@ import { join } from 'path';
 interface StoreSchema {
     pathToHistoryFile: string;
     maxNumberOfLinesInHistoryFile: number;
+    scrollback: number;
 }
 
 const store = getPersistentStore<StoreSchema>({
@@ -54,3 +55,5 @@ export const setMaxNumberOfLinesInHistoryFile = (size: number) => {
     _setMaxNumberOfLinesInHistoryFile(size);
     return true;
 };
+
+export const [getScrollback, setScrollback] = fromStore('scrollback', 10000);

--- a/src/features/terminal/terminalSlice.ts
+++ b/src/features/terminal/terminalSlice.ts
@@ -9,6 +9,10 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { AutoDetectTypes } from '@serialport/bindings-cpp';
 import type { SerialPortOpenOptions } from 'serialport';
 
+import {
+    getScrollback as getPersistedScrollback,
+    setScrollback as persistScrollback,
+} from '../../app/store';
 import type { RootState } from '../../appReducer';
 
 export type LineEnding = 'NONE' | 'LF' | 'CR' | 'CRLF';
@@ -41,7 +45,7 @@ const initialState: TerminalState = {
     lineMode: true,
     echoOnShell: true,
     showOverwriteDialog: false,
-    scrollback: 1000, // Default by Xterm.js
+    scrollback: getPersistedScrollback(), // Load from persistent storage
 };
 
 const cleanUndefined = <T>(obj: T) => JSON.parse(JSON.stringify(obj));
@@ -106,6 +110,7 @@ const terminalSlice = createSlice({
             { payload: scrollback }: PayloadAction<number>
         ) => {
             state.scrollback = scrollback;
+            persistScrollback(scrollback);
         },
         setWriteLogToFile: (
             state,


### PR DESCRIPTION
Persist the scrollback setting in local storage, so that it is restored when the app is restarted.