### PR TITLE
Make PRs trigger the build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,12 +2,14 @@ name: Build
 
 on:
     workflow_dispatch:
-    push:
-        branches-ignore:
-            - main # Skip for main because we build while releasing to "latest"
+        inputs:
+            ref:
+                description: 'The branch or tag to build'
+    pull_request:
+        types: [opened, reopened, synchronize]
 
 jobs:
     build:
         uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/build-app.yml@main
         with:
-            node_version: 18
+            ref: ${{ inputs.ref }}


### PR DESCRIPTION
Important for two reasons:

- When an outside contributor creates a PR, we want to run the build
  workflow to check that it builds correctly. This doesn't seem possible
  with the `push` trigger but with the `pull_request` trigger.

- The change in nordicsemi/pc-nrfconnect-shared#1099 becomes only
  effective for a repo, if the `pull_request` trigger is used.

This also enables selecting a ref when running the workflow manually.
